### PR TITLE
Rework GithubCheckRepositoryCommand

### DIFF
--- a/src/App/Command/RepositoryModel.php
+++ b/src/App/Command/RepositoryModel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Console\App\Command;
+
+class RepositoryModel
+{
+    public $name;
+    public $description;
+
+    public $html_url;
+    public $license;
+
+    public $has_issues;
+    public $stargazers_count;
+}

--- a/src/App/Command/TableDrawer.php
+++ b/src/App/Command/TableDrawer.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Console\App\Command;
+
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TableDrawer
+{
+    /**
+     * @param RepositoryModel[] $dataset
+     * @param OutputInterface $output
+     * @param int $timestamp
+     */
+    public function drawResultsAsTable(array $dataset, OutputInterface $output, $timestamp)
+    {
+        $countStars = $countWDescription = $countIssuesOpened = 0;
+        $countWLicense = [];
+
+        $table = new Table($output);
+        $table
+            ->setStyle('box')
+            ->setHeaders([
+                'Title',
+                '# Stars',
+                'Description',
+                'Issues Opened',
+                'License',
+            ]);
+
+        foreach ($dataset as $model) {
+
+            $table->addRows([[
+                sprintf(
+                    '<href=%s>%s</>',
+                    $model->html_url,
+                    $model->name
+                ),
+                $model->stargazers_count,
+                !empty($model->description) ? '<info>✓ </info>' : '<error>✗ </error>',
+                $model->has_issues ? '<info>✓ </info>' : '<error>✗ </error>',
+                $model->license,
+            ]]);
+
+            $countStars += $model->stargazers_count;
+            $countIssuesOpened += ($model->has_issues ? 1 : 0);
+            $countWDescription += (!empty($model->description) ? 1 : 0);
+
+            if (!empty($model->license)) {
+                if (!array_key_exists($model->license, $countWLicense)) {
+                    $countWLicense[$model->license] = 0;
+                }
+                $countWLicense[$model->license]++;
+            }
+
+            $table->addRows([new TableSeparator()]);
+        }
+
+        $licenseCell = '';
+        ksort($countWLicense);
+        foreach ($countWLicense as $license => $count) {
+            $licenseCell .= $license . ' : ' . $count;
+            if ($license !== array_key_last($countWLicense)) {
+                $licenseCell .= PHP_EOL;
+            }
+        }
+
+        $table->addRows([[
+            'Total : ' . count($dataset),
+            'Avg : ' . number_format($countStars / count($dataset), 2),
+            'Opened : ' . $countIssuesOpened . PHP_EOL . 'Closed : ' . (count($dataset) - $countIssuesOpened),
+            'Num : ' . $countWDescription,
+            $licenseCell,
+        ]]);
+
+        $table->render();
+        $output->writeLn(['', 'Output generated in ' . (time() - $timestamp) . 's.']);
+    }
+}


### PR DESCRIPTION
Here I refactor GithubCheckRepositoryCommand  to follow https://github.com/Progi1984/presthubot/issues/5

The idea would be to rework all commands following this strategy: separate data fetching, data construction and data rendering.

I did it quite quickly so code is not 100% clean.

**All Commands should do**
A. fetch data from github
B. build data as agnostic models
C. render data

### Benefits

1. All data can easily put in cache after step A
2. Allows easy integration tests without github: save real data, input it directly at step B
3. Allows extra processings on step B such as data enhancement, data filtering* ; and since the data is handled into models agnostic from github, they can easily be modified
4. Allow different outputs to be plugged in step C: currently it's an ASCII Table drawer, but we could output data as an HTML document or a JSON document
5. Allow piping: we could filter the data at step B to find all repos which need a release, and pass the relevant models to another Command that would create automatically the "Merge dev into master" branches